### PR TITLE
9 get lid for all patents missing a language

### DIFF
--- a/scripts/lid_patents.py
+++ b/scripts/lid_patents.py
@@ -1,54 +1,61 @@
-import pycld2 as cld2
-from google.cloud import bigquery
-import csv 
-import regex
-import pandas as pd 
-from alive_progress import alive_bar
+import csv
 
-#https://github.com/aboSamoor/polyglot/issues/71
+import pandas as pd
+import pycld2 as cld2
+import regex
+from alive_progress import alive_bar
+from google.cloud import bigquery
+
+# https://github.com/aboSamoor/polyglot/issues/71
 RE_BAD_CHARS = regex.compile(r"[\p{Cc}\p{Cs}]+")
 
 client = bigquery.Client()
 table_id = "gcp-cset-projects.staging_patent_clusters.patents_lid"
 
+
 def remove_bad_chars(text):
     return RE_BAD_CHARS.sub("", text)
 
-def data_connection():
-    QUERY = (
-        """
-        SELECT 
-            patent_id, 
-            title_original, 
+
+def connect_data():
+    QUERY = """
+        SELECT
+            patent_id,
+            title_original,
             abstract_original
         FROM `staging_patent_clusters.metadata_d_p_removed`
-        WHERE 
-            title is null 
+        WHERE
+            title is null
             and abstract is null
-            and title_original is not null 
+            and title_original is not null
             and abstract_original is not null
-        """)
+        """
 
     query_job = client.query(QUERY)  # API request
     return query_job.result()
 
-def translation(rows): 
+
+def translate(rows):
+    total_count = 11335511
     results = []
-    with alive_bar(11335511) as bar:
-        for row in rows: 
-            isReliable, textBytesFound, details = cld2.detect(remove_bad_chars(row['abstract_original']))
-            results.append([row['patent_id'], isReliable, details[0]])
+    with alive_bar(total_count) as bar:
+        for row in rows:
+            isReliable, textBytesFound, details = cld2.detect(
+                remove_bad_chars(row["abstract_original"])
+            )
+            results.append([row["patent_id"], isReliable, details[0]])
             bar()
     return results
+
 
 def write_results(results_frame):
     job_config = bigquery.LoadJobConfig(
         schema=[
             bigquery.SchemaField("patent_id", bigquery.enums.SqlTypeNames.STRING),
             bigquery.SchemaField("reliable", bigquery.enums.SqlTypeNames.STRING),
-            bigquery.SchemaField("details", bigquery.enums.SqlTypeNames.STRING), 
-            bigquery.SchemaField("language_long", bigquery.enums.SqlTypeNames.STRING), 
-            bigquery.SchemaField("language", bigquery.enums.SqlTypeNames.STRING)
+            bigquery.SchemaField("details", bigquery.enums.SqlTypeNames.STRING),
+            bigquery.SchemaField("language_long", bigquery.enums.SqlTypeNames.STRING),
+            bigquery.SchemaField("language", bigquery.enums.SqlTypeNames.STRING),
         ]
     )
 
@@ -64,13 +71,22 @@ def write_results(results_frame):
         )
     )
 
-if __name__ == '__main__':
-    rows = data_connection()
-    results = translation(rows)
-    results_frame = pd.DataFrame(results, columns=['patent_id', 'reliable', 'details'])
+
+if __name__ == "__main__":
+    rows = connect_data()
+    results = translate(rows)
+    results_frame = pd.DataFrame(results, columns=["patent_id", "reliable", "details"])
     for index, row in results_frame.iterrows():
-        test = row['details']
-        results_frame.loc[index, 'language_long'] = test[0]
-        results_frame.loc[index, 'language'] = test[1]
-    results_frame = results_frame.astype({'patent_id': str, 'reliable': str, 'details': str, 'language_long': str, 'language': str})
+        details = row["details"]
+        results_frame.loc[index, "language_long"] = details[0]
+        results_frame.loc[index, "language"] = details[1]
+    results_frame = results_frame.astype(
+        {
+            "patent_id": str,
+            "reliable": str,
+            "details": str,
+            "language_long": str,
+            "language": str,
+        }
+    )
     write_results(results_frame)


### PR DESCRIPTION
Script for conducting LID on patents & pushing results to BQ. 
The script checks unified patents for patents with a null English title/abstract and a non-null original title/abstract. This results in just over 11 million patents. 
For future deployment, this script should be changed to only pull patents that have not been LID'd. This can be done by doing the same check above, but adding a step of checking the created LID table (staging_patent_clusters.patent_lid)