### PR TITLE
create table of CPC text for family IDs 

### DIFF
--- a/sql/cpc_text.sql
+++ b/sql/cpc_text.sql
@@ -19,8 +19,8 @@ CREATE OR REPLACE TABLE staging_patent_clusters.family_cpc_text AS (
   text_join AS (
     SELECT
       family_id,
-      CONCAT(COALESCE(cpc_td.title, ''), COALESCE(cpc_td.description, '')) AS cpc_text,
-      CONCAT(COALESCE(ipc_td.title, ''), COALESCE(ipc_td.description, '')) AS ipc_text
+      CONCAT(COALESCE(cpc_td.title, ''), " ", COALESCE(cpc_td.description, '')) AS cpc_text,
+      CONCAT(COALESCE(ipc_td.title, ''), " ", COALESCE(ipc_td.description, '')) AS ipc_text
     FROM stage
     LEFT JOIN `cpc_codes.cpc_title_descriptions` AS cpc_td ON(cpcs = cpc_td.code)
     LEFT JOIN `cpc_codes.cpc_title_descriptions` AS ipc_td ON(ipcs = ipc_td.code)


### PR DESCRIPTION
Current commit does not yet create a table in staging_patent_clusters.

First, get CPC/IPC codes for patents in our design/plant patent removed dataset. Adjust strings so they match CPC table. 

Then, concatenate titles and descriptions where available for both CPC and IPC codes. 

Then, aggregate at the family level, removing duplicates and ordering alphabetically. 

Lastly, take first CPC text, then IPC text if CPC is null. 