### PR TITLE
56 make cluster keywords

### DIFF
--- a/scripts/patent_text_sim.py
+++ b/scripts/patent_text_sim.py
@@ -2,7 +2,7 @@ import csv
 import json
 import os
 import sys
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from typing import Optional
 
 import yake
@@ -71,10 +71,9 @@ class Postprocessor:
         """
         # if phrase is not a single word
         if len(phrase.split()) > 1:
-            # remove duplicates and rebuild string
-            unique_words = set(phrase.split())
-            unique_words_string = " ".join(unique_words)
-            return unique_words_string
+            # remove duplicates while maintaining order and rebuild string
+            unique_words = " ".join(OrderedDict.fromkeys(phrase.split()))
+            return unique_words
         # if phrase is a single word
         else:
             if " " not in phrase.strip():

--- a/sql/cluster_family_text_data.sql
+++ b/sql/cluster_family_text_data.sql
@@ -5,7 +5,6 @@ keyword extraction.
 SELECT
   cluster_id,
   family_id,
-  cpc_text,
   text AS title_abstract
 FROM `staging_patent_clusters.cluster_assignment`
 LEFT JOIN `staging_patent_clusters.family_cpc_text` USING (family_id)


### PR DESCRIPTION
PR for patent cluster keyword extraction 

- `cluster_family_text_data.sql` = SQL code for creating `cluster_id: family_id: title_abstract_text` table (to run yake over) 
- `patent_text_sim.py` = Python script for running yake and storing results by patent cluster id 

NOTE: `patent_text_sim.py` needs to be altered to handle GCP buckets [here is the link to MOS KY extraction,](https://github.com/georgetown-cset/science_map/blob/master/helpers/text_sim.py) in case that helps illuminate how to adjust it. Seems pretty easy - just set the os.path to the data bucket? 