### PR TITLE
Increase size of embedding VM so it doesn't crash installing dependencies

### DIFF
--- a/patent_hybrid_clustering_dag.py
+++ b/patent_hybrid_clustering_dag.py
@@ -319,7 +319,7 @@ with DAG(
                     "boot": True,
                     "auto_delete": True,
                     "initialize_params": {
-                        "disk_size_gb": "20",
+                        "disk_size_gb": "30",
                         "disk_type": f"zones/{gce_zone}/diskTypes/pd-balanced",
                         "source_image": "projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20240927",
                     },


### PR DESCRIPTION
It seemed like 20GB was enough (the 15GB limit of the Airflow worker was just not quite enough?) but then it crashed the next run. So I'm giving it 30 and hoping I never have to worry at that limit. So far so good.