### PR TITLE
added trigger for eto_mop_bq_to_bq_metadata DAG

### DIFF
--- a/patent_hybrid_clustering_dag.py
+++ b/patent_hybrid_clustering_dag.py
@@ -9,6 +9,7 @@ from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import BranchPythonOperator, PythonOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.providers.apache.beam.operators.beam import BeamRunPythonPipelineOperator
 from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryCheckOperator,
@@ -909,3 +910,10 @@ with DAG(
             >> table_backup
             >> wait_for_production_backups
         )
+
+    trigger_mop = TriggerDagRunOperator(
+        task_id="trigger_eto_mop_bq_to_bq_metadata",
+        trigger_dag_id="eto_mop_bq_to_bq_metadata",
+    )
+
+    success_alert >> trigger_mop


### PR DESCRIPTION
added a trigger for the [`eto_mop_bq_to_bq_metadata DAG`](https://d7c5f2369fea46beb8ec7a3532550598-dot-us-east1.composer.googleusercontent.com/dags/eto_mop_bq_to_bq_metadata/grid?search=eto_mop_bq_to_bq_metadata) after a successful run